### PR TITLE
Fix orientation listener cleanup

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,7 +18,13 @@ const theme = createTheme();
 const App: React.FC = () => {
     const [battleRoom, setBattleRoom] = useState<null | Room>(null);
     const [dragging, setDragging] = useState(false);
-    const [orientation, setOrientation] = useState(screen.orientation.type);
+    const [orientation, setOrientation] = useState(
+        screen.orientation
+            ? screen.orientation.type
+            : window.innerWidth > window.innerHeight
+                ? 'landscape-primary'
+                : 'portrait-primary'
+    );
 
     // const launchParams = useLaunchParams();
 
@@ -30,15 +36,26 @@ const App: React.FC = () => {
         }
     }, [battleRoom])
 
-    useEffect(() => {
-        screen.orientation.addEventListener('change', () => {
-            setOrientation(screen.orientation.type);
-        });
+    const handleOrientationChange = () => {
+        setOrientation(
+            screen.orientation
+                ? screen.orientation.type
+                : window.innerWidth > window.innerHeight
+                    ? 'landscape-primary'
+                    : 'portrait-primary'
+        );
+    };
 
+    useEffect(() => {
+        if (screen.orientation) {
+            screen.orientation.addEventListener('change', handleOrientationChange);
+            return () => {
+                screen.orientation.removeEventListener('change', handleOrientationChange);
+            };
+        }
+        window.addEventListener('resize', handleOrientationChange);
         return () => {
-            screen.orientation.removeEventListener('change', () => {
-                setOrientation(screen.orientation.type);
-            });
+            window.removeEventListener('resize', handleOrientationChange);
         };
     }, []);
 


### PR DESCRIPTION
## Summary
- ensure orientation listener uses the same handler
- fallback to a resize-based orientation check when `screen.orientation` is not available

## Testing
- `npm run lint` *(fails: @typescript-eslint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6849537e4c80832fa9e37ee0929906c3