### PR TITLE
Fix useGameSocket effect

### DIFF
--- a/src/hooks/useGameSocket.ts
+++ b/src/hooks/useGameSocket.ts
@@ -20,9 +20,8 @@ export function useGameSocket() {
 
     const room = useRoom()
 
-    localStorage.setItem('reconnectionToken', room.reconnectionToken);
-
     useEffect(() => {
+        localStorage.setItem('reconnectionToken', room.reconnectionToken);
         // Синхронизируем при каждом изменении состояния комнаты
         room.onStateChange((state) => {
             // Текущий игрок
@@ -128,5 +127,9 @@ export function useGameSocket() {
                 opponentRemaining: msg.opponentRemaining,
             }));
         });
-    });
+
+        return () => {
+            room.removeAllListeners();
+        };
+    }, [room]);
 }


### PR DESCRIPTION
## Summary
- add `room` dependency to `useGameSocket` effect
- set reconnection token only once and cleanup listeners when leaving

## Testing
- `yarn lint` *(fails: Unexpected any errors, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684953947e70832fbf957c7d8ed495c9